### PR TITLE
fix: WorkManager crash causing `ForegroundServiceStartNotAllowedException`

### DIFF
--- a/app/src/main/kotlin/dev/yashgarg/qbit/MainActivity.kt
+++ b/app/src/main/kotlin/dev/yashgarg/qbit/MainActivity.kt
@@ -51,13 +51,13 @@ class MainActivity : AppCompatActivity() {
                 checkPermissions(applicationContext)
             }
 
-            serverPrefsStore.data
-                .map { it.showNotification }
-                .onEach(::launchWorkManager)
-                .launchIn(lifecycleScope)
-
             lifecycleScope.launch {
-                lifecycle.whenResumed {
+                whenResumed {
+                    serverPrefsStore.data
+                        .map { it.showNotification }
+                        .onEach(::launchWorkManager)
+                        .launchIn(lifecycleScope)
+
                     clientManager.configStatus.collect { status ->
                         when (status) {
                             ConfigStatus.EXISTS -> {

--- a/common/src/main/kotlin/dev/yashgarg/qbit/notifications/AppNotificationManager.kt
+++ b/common/src/main/kotlin/dev/yashgarg/qbit/notifications/AppNotificationManager.kt
@@ -67,7 +67,7 @@ object AppNotificationManager {
                 .setSmallIcon(smallIcon)
                 .setContentTitle(title)
                 .setContentText(content)
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setContentIntent(contentIntent)
                 .setAutoCancel(!persistent)
                 .setOngoing(persistent)


### PR DESCRIPTION
#### Play Console StackTrace

```kotlin
Exception android.app.ForegroundServiceStartNotAllowedException:
  at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel (ForegroundServiceStartNotAllowedException.java:54)
  at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel (ForegroundServiceStartNotAllowedException.java:50)
  at android.os.Parcel.readParcelable (Parcel.java:3333)
  at android.os.Parcel.createExceptionOrNull (Parcel.java:2420)
  at android.os.Parcel.createException (Parcel.java:2409)
  at android.os.Parcel.readException (Parcel.java:2392)
  at android.os.Parcel.readException (Parcel.java:2334)
  at android.app.IActivityManager$Stub$Proxy.setServiceForeground (IActivityManager.java:7288)
  at android.app.Service.startForeground (Service.java:786)
  at androidx.work.impl.foreground.SystemForegroundService$1.run (SystemForegroundService.java)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:210)
  at android.os.Looper.loop (Looper.java:299)
  at android.app.ActivityThread.main (ActivityThread.java:8105)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:556)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1045)
Caused by android.os.RemoteException: Remote stack trace:
  at com.android.server.am.ActiveServices.setServiceForegroundInnerLocked (ActiveServices.java:1859)
  at com.android.server.am.ActiveServices.setServiceForegroundLocked (ActiveServices.java:1368)
  at com.android.server.am.ActivityManagerService.setServiceForeground (ActivityManagerService.java:12229)
  at android.app.IActivityManager$Stub.onTransact (IActivityManager.java:3293)
  at com.android.server.am.ActivityManagerService.onTransact (ActivityManagerService.java:2559)
```